### PR TITLE
Support cdart in addition to discart for Music Visualization

### DIFF
--- a/16x9/MusicVisualisation.xml
+++ b/16x9/MusicVisualisation.xml
@@ -733,6 +733,7 @@
 							<visible>!Skin.HasSetting(HideMusicVizCD)</visible>
 						</control>
 						<control type="group">
+							<visible>String.IsEmpty(Player.Art(album.cdart)) + String.IsEmpty(Player.Art(cdart))</visible>
 							<visible>String.IsEmpty(Player.Art(album.discart)) + String.IsEmpty(Player.Art(discart))</visible>
 							<visible>!Skin.HasSetting(HideMusicVizCD) + !Skin.HasSetting(MusicDiscFallback.Vinyl)</visible>
 							<control type="label">

--- a/16x9/Variables.xml
+++ b/16x9/Variables.xml
@@ -833,6 +833,8 @@
 		<value>$INFO[ListItem.Art(clearlogo)]</value>
 	</variable>
 	<variable name="PlayerArtworkDiscVar">
+		<value condition="!String.IsEmpty(Player.Art(album.cdart))">$INFO[Player.Art(album.cdart)]</value>
+		<value condition="!String.IsEmpty(Player.Art(cdart))">$INFO[Player.Art(cdart)]</value>
 		<value condition="!String.IsEmpty(Player.Art(album.discart))">$INFO[Player.Art(album.discart)]</value>
 		<value condition="!String.IsEmpty(Player.Art(discart))">$INFO[Player.Art(discart)]</value>
 		<value condition="Skin.HasSetting(MusicDiscFallback.Vinyl)">special://skin/extras/cdart/vinyl.png</value>


### PR DESCRIPTION
Feature request #90.
- When computing `PlayerArtworkDiscVar`, consider `cdart` in addition to `discart`
- When checking whether to show labels on spinning CD, also check if `cdart` is defined in addition to `discart`