### PR TITLE
Fix FloorSubLabelVar duration for TV Shows  

### DIFF
--- a/16x9/Variables.xml
+++ b/16x9/Variables.xml
@@ -779,7 +779,7 @@
 	</variable>
 	<variable name="FloorSubLabelVar">
 		<value condition="ListItem.IsCollection">$INFO[Container(4500).NumItems,, $LOCALIZE[342]]</value>
-		<value condition="[Container.Content(tvshows) | Container.Content(seasons)] + !Skin.HasSetting(Enable.HourMinuteDuration)">$INFO[ListItem.Year]$INFO[ListItem.RatingAndVotes, • ]$INFO[ListItem.Duration(mins),, $LOCALIZE[12391]]</value>
+		<value condition="[Container.Content(tvshows) | Container.Content(seasons)] + !Skin.HasSetting(Enable.HourMinuteDuration)">$INFO[ListItem.Year]$INFO[ListItem.RatingAndVotes, • ]$INFO[ListItem.Duration(mins), • , $LOCALIZE[12391]]</value>
 		<value condition="[Container.Content(tvshows) | Container.Content(seasons)] + Skin.HasSetting(Enable.HourMinuteDuration)">$INFO[ListItem.Year]$INFO[ListItem.RatingAndVotes, • ]$VAR[ItemDurationVar, • ]</value>
 		<value condition="Container.Content(episodes)">$INFO[ListItem.TvShowTitle]</value>
 		<value condition="Container.Content(addons)">$INFO[ListItem.AddonSummary]</value>


### PR DESCRIPTION
For TV Shows, the year and runtime (in minutes) are merged into one figure; add the middle circle to "ListItem.Duration(mins)", see screenshots:
![01_before](https://github.com/user-attachments/assets/976c0088-0d37-4d25-a4a7-f6e57e487dcd)
![02_after](https://github.com/user-attachments/assets/d99a471a-19f6-4f22-b507-3110f57cb418)
