### PR TITLE
Support Danish MPAA ratings with PlexKodiConnect

### DIFF
--- a/16x9/Variables_Artwork.xml
+++ b/16x9/Variables_Artwork.xml
@@ -389,10 +389,10 @@
 		<value condition="String.Contains(ListItem.MPAA,GR:12)">GR-12.png</value>
 		<value condition="String.Contains(ListItem.MPAA,GR:16)">GR-16.png</value>
 		<value condition="String.Contains(ListItem.MPAA,GR:18)">GR-18.png</value>
-		<value condition="String.Contains(ListItem.MPAA,DK:A) | String.IsEqual(ListItem.MPAA,Denmark:A)">MCCYP_Denmark-A.png</value>
-		<value condition="String.Contains(ListItem.MPAA,DK:7) | String.IsEqual(ListItem.MPAA,Denmark:7)">MCCYP_Denmark-7.png</value>
-		<value condition="String.Contains(ListItem.MPAA,DK:11) | String.IsEqual(ListItem.MPAA,Denmark:11)">MCCYP_Denmark-11.png</value>
-		<value condition="String.Contains(ListItem.MPAA,DK:15) | String.IsEqual(ListItem.MPAA,Denmark:15)">MCCYP_Denmark-15.png</value>
+		<value condition="String.Contains(ListItem.MPAA,DK:A) | String.Contains(ListItem.MPAA,Denmark:A) | String.Contains(ListItem.MPAA,dk/A)">MCCYP_Denmark-A.png</value>
+		<value condition="String.Contains(ListItem.MPAA,DK:7) | String.Contains(ListItem.MPAA,Denmark:7) | String.Contains(ListItem.MPAA,dk/7)">MCCYP_Denmark-7.png</value>
+		<value condition="String.Contains(ListItem.MPAA,DK:11) | String.Contains(ListItem.MPAA,Denmark:11) | String.Contains(ListItem.MPAA,dk/11)">MCCYP_Denmark-11.png</value>
+		<value condition="String.Contains(ListItem.MPAA,DK:15) | String.Contains(ListItem.MPAA,Denmark:15) | String.Contains(ListItem.MPAA,dk/15)">MCCYP_Denmark-15.png</value>
 		<value condition="String.IsEmpty(ListItem.MPAA) | String.Contains(ListItem.MPAA,NR) | String.IsEqual(ListItem.MPAA,Rated) | String.IsEqual(ListItem.MPAA,Rated ) | String.IsEqual(ListItem.MPAA,Not Rated)">NR.png</value>
 		<value>$INFO[ListItem.MPAA,,.png]</value>
 	</variable>
@@ -458,10 +458,10 @@
 		<value condition="String.Contains(VideoPlayer.MPAA,GR:12)">GR-12.png</value>
 		<value condition="String.Contains(VideoPlayer.MPAA,GR:16)">GR-16.png</value>
 		<value condition="String.Contains(VideoPlayer.MPAA,GR:18)">GR-18.png</value>
-		<value condition="String.Contains(VideoPlayer.MPAA,DK:A) | String.Contains(VideoPlayer.MPAA,Denmark:A)">MCCYP_Denmark-A.png</value>
-		<value condition="String.Contains(VideoPlayer.MPAA,DK:7) | String.Contains(VideoPlayer.MPAA,Denmark:7)">MCCYP_Denmark-7.png</value>
-		<value condition="String.Contains(VideoPlayer.MPAA,DK:11) | String.Contains(VideoPlayer.MPAA,Denmark:11)">MCCYP_Denmark-11.png</value>
-		<value condition="String.Contains(VideoPlayer.MPAA,DK:15) | String.Contains(VideoPlayer.MPAA,Denmark:15)">MCCYP_Denmark-15.png</value>
+		<value condition="String.Contains(VideoPlayer.MPAA,DK:A) | String.Contains(VideoPlayer.MPAA,Denmark:A) | String.Contains(VideoPlayer.MPAA,dk/A)">MCCYP_Denmark-A.png</value>
+		<value condition="String.Contains(VideoPlayer.MPAA,DK:7) | String.Contains(VideoPlayer.MPAA,Denmark:7) | String.Contains(VideoPlayer.MPAA,dk/7)">MCCYP_Denmark-7.png</value>
+		<value condition="String.Contains(VideoPlayer.MPAA,DK:11) | String.Contains(VideoPlayer.MPAA,Denmark:11) | String.Contains(VideoPlayer.MPAA,dk/11)">MCCYP_Denmark-11.png</value>
+		<value condition="String.Contains(VideoPlayer.MPAA,DK:15) | String.Contains(VideoPlayer.MPAA,Denmark:15) | String.Contains(VideoPlayer.MPAA,dk/15)">MCCYP_Denmark-15.png</value>
 		<value>$INFO[VideoPlayer.MPAA,,.png]</value>
 	</variable>
 	<variable name="CustomRatingFlagVar">
@@ -526,10 +526,10 @@
 		<value condition="String.Contains(Container(4800).ListItem.MPAA,GR:12)">GR-12.png</value>
 		<value condition="String.Contains(Container(4800).ListItem.MPAA,GR:16)">GR-16.png</value>
 		<value condition="String.Contains(Container(4800).ListItem.MPAA,GR:18)">GR-18.png</value>
-		<value condition="String.Contains(Container(4800).ListItem.MPAA,DK:A) | String.IsEqual(Container(4800).ListItem.MPAA,Denmark:A)">MCCYP_Denmark-A.png</value>
-		<value condition="String.Contains(Container(4800).ListItem.MPAA,DK:7) | String.IsEqual(Container(4800).ListItem.MPAA,Denmark:7)">MCCYP_Denmark-7.png</value>
-		<value condition="String.Contains(Container(4800).ListItem.MPAA,DK:11) | String.IsEqual(Container(4800).ListItem.MPAA,Denmark:11)">MCCYP_Denmark-11.png</value>
-		<value condition="String.Contains(Container(4800).ListItem.MPAA,DK:15) | String.IsEqual(Container(4800).ListItem.MPAA,Denmark:15)">MCCYP_Denmark-15.png</value>
+		<value condition="String.Contains(Container(4800).ListItem.MPAA,DK:A) | String.Contains(Container(4800).ListItem.MPAA,Denmark:A) | String.Contains(Container(4800).ListItem.MPAA,dk/A)">MCCYP_Denmark-A.png</value>
+		<value condition="String.Contains(Container(4800).ListItem.MPAA,DK:7) | String.Contains(Container(4800).ListItem.MPAA,Denmark:7) | String.Contains(Container(4800).ListItem.MPAA,dk/7)">MCCYP_Denmark-7.png</value>
+		<value condition="String.Contains(Container(4800).ListItem.MPAA,DK:11) | String.Contains(Container(4800).ListItem.MPAA,Denmark:11) | String.Contains(Container(4800).ListItem.MPAA,dk/11)">MCCYP_Denmark-11.png</value>
+		<value condition="String.Contains(Container(4800).ListItem.MPAA,DK:15) | String.Contains(Container(4800).ListItem.MPAA,Denmark:15) | String.Contains(Container(4800).ListItem.MPAA,dk/15)">MCCYP_Denmark-15.png</value>
 		<value condition="String.IsEmpty(Container(4800).ListItem.MPAA) | String.Contains(Container(4800).ListItem.MPAA,NR) | String.IsEqual(Container(4800).ListItem.MPAA,Rated) | String.IsEqual(Container(4800).ListItem.MPAA,Rated ) | String.IsEqual(Container(4800).ListItem.MPAA,Not Rated)">NR.png</value>
 		<value condition="!String.IsEmpty(Window(Home).Property(item_dbid))">$INFO[Container(4800).ListItem.MPAA,,.png]</value>
 		<value>$INFO[Container(4801).ListItem.MPAA,,.png]</value>
@@ -590,10 +590,10 @@
 		<value condition="String.Contains(Container(4500).ListItem(0).MPAA,GR:12)">GR-12.png</value>
 		<value condition="String.Contains(Container(4500).ListItem(0).MPAA,GR:16)">GR-16.png</value>
 		<value condition="String.Contains(Container(4500).ListItem(0).MPAA,GR:18)">GR-18.png</value>
-		<value condition="String.Contains(Container(4500).ListItem(0).MPAA,DK:A) | String.Contains(Container(4500).ListItem(0).MPAA,Denmark:A)">MCCYP_Denmark-A.png</value>
-		<value condition="String.Contains(Container(4500).ListItem(0).MPAA,DK:7) | String.Contains(Container(4500).ListItem(0).MPAA,Denmark:7)">MCCYP_Denmark-7.png</value>
-		<value condition="String.Contains(Container(4500).ListItem(0).MPAA,DK:11) | String.Contains(Container(4500).ListItem(0).MPAA,Denmark:11)">MCCYP_Denmark-11.png</value>
-		<value condition="String.Contains(Container(4500).ListItem(0).MPAA,DK:15) | String.Contains(Container(4500).ListItem(0).MPAA,Denmark:15)">MCCYP_Denmark-15.png</value>
+		<value condition="String.Contains(Container(4500).ListItem(0).MPAA,DK:A) | String.Contains(Container(4500).ListItem(0).MPAA,Denmark:A) | String.Contains(Container(4500).ListItem(0).MPAA,dk/A)">MCCYP_Denmark-A.png</value>
+		<value condition="String.Contains(Container(4500).ListItem(0).MPAA,DK:7) | String.Contains(Container(4500).ListItem(0).MPAA,Denmark:7) | String.Contains(Container(4500).ListItem(0).MPAA,dk/7)">MCCYP_Denmark-7.png</value>
+		<value condition="String.Contains(Container(4500).ListItem(0).MPAA,DK:11) | String.Contains(Container(4500).ListItem(0).MPAA,Denmark:11) | String.Contains(Container(4500).ListItem(0).MPAA,dk/11)">MCCYP_Denmark-11.png</value>
+		<value condition="String.Contains(Container(4500).ListItem(0).MPAA,DK:15) | String.Contains(Container(4500).ListItem(0).MPAA,Denmark:15) | String.Contains(Container(4500).ListItem(0).MPAA,dk/15)">MCCYP_Denmark-15.png</value>
 		<value>$INFO[Container(4500).ListItem(0).MPAA,,.png]</value>
 	</variable>
 	<variable name="StudioIconVar">


### PR DESCRIPTION
Updated to support Danish film classifications (MCCYP) when using KODI with the add-on: "PlexKodiConnect".
MCCYP formats:
dk/A
dk/7
dk/11
dk/15